### PR TITLE
fix wrong description property in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ For more creative freedom, Pizzicato also allows direct audio processing. Sounds
 For example:
 ```javascript
 var whiteNoise = Pizzicato.Sound({
-    type: 'script',
+    source: 'script',
     options: {
         audioFunction: function(e) {
             var output = e.outputBuffer.getChannelData(0);


### PR DESCRIPTION
This PR fixes a simple error in the repo readme.

https://github.com/alemangui/pizzicato/blob/master/src/Sound.js#L45-L46

