### PR TITLE
added missing curly braces to prevent build errors

### DIFF
--- a/distr/Pizzicato.js
+++ b/distr/Pizzicato.js
@@ -209,7 +209,7 @@
 	
 		this.masterVolume = Pizzicato.context.createGain();
 		this.fadeNode = Pizzicato.context.createGain();
-		
+	
 		if (!hasOptions || !description.options.detached)
 			this.masterVolume.connect(Pizzicato.masterGainNode);
 	
@@ -331,8 +331,9 @@
 			};
 			request.onreadystatechange = function(event) {
 	
-				if (request.readyState === 4 && request.status !== 200)
+				if (request.readyState === 4 && request.status !== 200) {
 					console.error('Error while fetching ' + paths[0] + '. ' + request.statusText);
+				}
 			};
 			request.send();
 		}
@@ -451,7 +452,7 @@
 				this.stopWithRelease();
 	
 				var elapsedTime = Pz.context.currentTime - this.lastTimePlayed;
-				
+	
 				// If we are using a buffer node - potentially in loop mode - we need to
 				// know where to re-start the sound independently of the loop it is in.
 				if (this.sourceNode.buffer)
@@ -638,7 +639,7 @@
 	
 		/**
 		 * Returns the node that produces the sound. For example, an oscillator
-		 * if the Sound object was initialized with a wave option. 
+		 * if the Sound object was initialized with a wave option.
 		 */
 		getSourceNode: {
 			enumerable: true,
@@ -1356,7 +1357,7 @@
 		this.dryGainNode.connect(this.outputNode);
 		this.wetGainNode.connect(this.outputNode);
 	
-		
+	
 		for (var key in defaults) {
 			this[key] = options[key];
 			this[key] = (this[key] === undefined || this[key] === null) ? defaults[key] : this[key];
@@ -1366,7 +1367,7 @@
 			console.error('No impulse file specified.');
 			return;
 		}
-		
+	
 		request.open('GET', options.impulse, true);
 		request.responseType = 'arraybuffer';
 		request.onload = function (e) {
@@ -1376,7 +1377,7 @@
 	
 				self.convolverNode.buffer = buffer;
 	
-				if (self.callback && Pz.Util.isFunction(self.callback)) 
+				if (self.callback && Pz.Util.isFunction(self.callback))
 					self.callback();
 	
 			}, function(error) {
@@ -1389,8 +1390,9 @@
 		};
 	
 		request.onreadystatechange = function(event) {
-			if (request.readyState === 4 && request.status !== 200)
+			if (request.readyState === 4 && request.status !== 200) {
 				console.error('Error while fetching ' + options.impulse + '. ' + request.statusText);
+			}
 		};
 	
 		request.send();
@@ -1400,7 +1402,7 @@
 	
 		mix: {
 			enumerable: true,
-			
+	
 			get: function() {
 				return this.options.mix;
 			},

--- a/site/Pizzicato.js
+++ b/site/Pizzicato.js
@@ -209,7 +209,7 @@
 	
 		this.masterVolume = Pizzicato.context.createGain();
 		this.fadeNode = Pizzicato.context.createGain();
-		
+	
 		if (!hasOptions || !description.options.detached)
 			this.masterVolume.connect(Pizzicato.masterGainNode);
 	
@@ -331,8 +331,9 @@
 			};
 			request.onreadystatechange = function(event) {
 	
-				if (request.readyState === 4 && request.status !== 200)
+				if (request.readyState === 4 && request.status !== 200) {
 					console.error('Error while fetching ' + paths[0] + '. ' + request.statusText);
+				}
 			};
 			request.send();
 		}
@@ -451,7 +452,7 @@
 				this.stopWithRelease();
 	
 				var elapsedTime = Pz.context.currentTime - this.lastTimePlayed;
-				
+	
 				// If we are using a buffer node - potentially in loop mode - we need to
 				// know where to re-start the sound independently of the loop it is in.
 				if (this.sourceNode.buffer)
@@ -638,7 +639,7 @@
 	
 		/**
 		 * Returns the node that produces the sound. For example, an oscillator
-		 * if the Sound object was initialized with a wave option. 
+		 * if the Sound object was initialized with a wave option.
 		 */
 		getSourceNode: {
 			enumerable: true,
@@ -1356,7 +1357,7 @@
 		this.dryGainNode.connect(this.outputNode);
 		this.wetGainNode.connect(this.outputNode);
 	
-		
+	
 		for (var key in defaults) {
 			this[key] = options[key];
 			this[key] = (this[key] === undefined || this[key] === null) ? defaults[key] : this[key];
@@ -1366,7 +1367,7 @@
 			console.error('No impulse file specified.');
 			return;
 		}
-		
+	
 		request.open('GET', options.impulse, true);
 		request.responseType = 'arraybuffer';
 		request.onload = function (e) {
@@ -1376,7 +1377,7 @@
 	
 				self.convolverNode.buffer = buffer;
 	
-				if (self.callback && Pz.Util.isFunction(self.callback)) 
+				if (self.callback && Pz.Util.isFunction(self.callback))
 					self.callback();
 	
 			}, function(error) {
@@ -1389,8 +1390,9 @@
 		};
 	
 		request.onreadystatechange = function(event) {
-			if (request.readyState === 4 && request.status !== 200)
+			if (request.readyState === 4 && request.status !== 200) {
 				console.error('Error while fetching ' + options.impulse + '. ' + request.statusText);
+			}
 		};
 	
 		request.send();
@@ -1400,7 +1402,7 @@
 	
 		mix: {
 			enumerable: true,
-			
+	
 			get: function() {
 				return this.options.mix;
 			},

--- a/src/Effects/Convolver.js
+++ b/src/Effects/Convolver.js
@@ -26,7 +26,7 @@ Pizzicato.Effects.Convolver = function(options, callback) {
 	this.dryGainNode.connect(this.outputNode);
 	this.wetGainNode.connect(this.outputNode);
 
-	
+
 	for (var key in defaults) {
 		this[key] = options[key];
 		this[key] = (this[key] === undefined || this[key] === null) ? defaults[key] : this[key];
@@ -36,7 +36,7 @@ Pizzicato.Effects.Convolver = function(options, callback) {
 		console.error('No impulse file specified.');
 		return;
 	}
-	
+
 	request.open('GET', options.impulse, true);
 	request.responseType = 'arraybuffer';
 	request.onload = function (e) {
@@ -46,7 +46,7 @@ Pizzicato.Effects.Convolver = function(options, callback) {
 
 			self.convolverNode.buffer = buffer;
 
-			if (self.callback && Pz.Util.isFunction(self.callback)) 
+			if (self.callback && Pz.Util.isFunction(self.callback))
 				self.callback();
 
 		}, function(error) {
@@ -59,8 +59,9 @@ Pizzicato.Effects.Convolver = function(options, callback) {
 	};
 
 	request.onreadystatechange = function(event) {
-		if (request.readyState === 4 && request.status !== 200)
+		if (request.readyState === 4 && request.status !== 200) {
 			console.error('Error while fetching ' + options.impulse + '. ' + request.statusText);
+		}
 	};
 
 	request.send();
@@ -70,7 +71,7 @@ Pizzicato.Effects.Convolver.prototype = Object.create(baseEffect, {
 
 	mix: {
 		enumerable: true,
-		
+
 		get: function() {
 			return this.options.mix;
 		},

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -13,7 +13,7 @@ Pizzicato.Sound = function(description, callback) {
 
 	this.masterVolume = Pizzicato.context.createGain();
 	this.fadeNode = Pizzicato.context.createGain();
-	
+
 	if (!hasOptions || !description.options.detached)
 		this.masterVolume.connect(Pizzicato.masterGainNode);
 
@@ -135,8 +135,9 @@ Pizzicato.Sound = function(description, callback) {
 		};
 		request.onreadystatechange = function(event) {
 
-			if (request.readyState === 4 && request.status !== 200)
+			if (request.readyState === 4 && request.status !== 200) {
 				console.error('Error while fetching ' + paths[0] + '. ' + request.statusText);
+			}
 		};
 		request.send();
 	}
@@ -255,7 +256,7 @@ Pizzicato.Sound.prototype = Object.create(Pizzicato.Events, {
 			this.stopWithRelease();
 
 			var elapsedTime = Pz.context.currentTime - this.lastTimePlayed;
-			
+
 			// If we are using a buffer node - potentially in loop mode - we need to
 			// know where to re-start the sound independently of the loop it is in.
 			if (this.sourceNode.buffer)
@@ -442,7 +443,7 @@ Pizzicato.Sound.prototype = Object.create(Pizzicato.Events, {
 
 	/**
 	 * Returns the node that produces the sound. For example, an oscillator
-	 * if the Sound object was initialized with a wave option. 
+	 * if the Sound object was initialized with a wave option.
 	 */
 	getSourceNode: {
 		enumerable: true,


### PR DESCRIPTION
I am getting build errors when building my project as I have a grunt task that strips all console.logs before uglifying my JSPM bundle.js.
Adding curly braces around the following lines in Sound.js and Convolver.js fixes the problem.

```
if (request.readyState === 4 && request.status !== 200) {
    console.error('Error while fetching ' + paths[0] + '. ' + request.statusText);
}
```