### PR TITLE
Add a new creation type 'element', which from a audio element.

### DIFF
--- a/src/Sound.js
+++ b/src/Sound.js
@@ -60,6 +60,8 @@ Pizzicato.Sound = function(description, callback) {
 	else if (description.source === 'sound')
 		(initializeWithSoundObject.bind(this))(description.options, callback);
 
+	else if (description.source === 'element')
+		(initializeWithSoundElement.bind(this))(description.options, callback);
 
 	function getDescriptionError(description) {
 		var supportedSources = ['wave', 'file', 'input', 'script', 'sound'];
@@ -204,6 +206,20 @@ Pizzicato.Sound = function(description, callback) {
 			this.frequency = options.sound.frequency;
 		}
 	}
+
+	function initializeWithSoundElement(options, callback) {
+		if (options.selector) {
+			options.player = document.querySelector(options.selector);
+		}
+		if (!options.player instanceof HTMLAudioElement) {
+			console.error('Error Element Type');
+			return;
+		}
+		this.getRawSourceNode = function() {
+			return Pizzicato.context.createMediaElementSource(options.player);
+		};
+	}
+	
 };
 
 


### PR DESCRIPTION
Create a sound like 
```js
const sound = new Pizzicato.Sound({ 
    source: 'element',
    options: { selector: '#eId' }
});
```
or
```js
const sound = new Pizzicato.Sound({ 
    source: 'element',
    options: { player: document.getElementById('eId') }
});
```

Pizzicato does not work on iOS, but audio elements created by user interaction events can be played.  
For example, Pizzicato can work like this:
```js
document.getElementsByTagName('body')[0].addEventListener('touchend', (e) => {
    // create in a interaction event
    const au = document.createElement('audio');
    au.preload = 'preload';
    au.addEventListener('canplay', function() {
        const sound = new Pizzicato.Sound({
            source: 'element',
            options: {
                player: au
            }
        }, () => {
            sound.play();
        });
    });
    au.src = url;
}, true);
```
