### PR TITLE
Fix optional parameters of connect shim

### DIFF
--- a/src/Shims.js
+++ b/src/Shims.js
@@ -4,8 +4,12 @@ var gainNode = Pizzicato.context.createGain();
 var audioNode = Object.getPrototypeOf(Object.getPrototypeOf(gainNode));
 var connect = audioNode.connect;
 
-audioNode.connect = function(node) {
+audioNode.connect = function(node, output, input) {
 	var endpoint = Pz.Util.isEffect(node) ? node.inputNode : node;
-	connect.call(this, endpoint);
+	if (input === undefined) {
+		connect.call(this, endpoint, output);
+	} else {
+		connect.call(this, endpoint, output, input);
+	}
 	return node;
 };


### PR DESCRIPTION
Hi @alemangui,

I noticed a little bug which this pull request tries to fix. Since pizzicato patches the native AudioNode and doesn't pass on the optional parameters for the input and output channels it makes them inaccessible for any other code running on the same page.

Here is a little snippet which does currently not work when pizzicato is also loaded on the same page:

```js
var splitter = ac.createChannelSplitter(2);
var merger = ac.createChannelMerger(2);

splitter.connect(merger, 1, 0);
splitter.connect(merger, 0, 1);
```

Please let me know if you want me to make changes to this pull request.