### PR TITLE
Fix identification of OscillatorNode objects in Safari v14+. Fixes #146.

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -32,7 +32,7 @@ Pizzicato.Util = {
 	},
 
 	isOscillator: function(audioNode) {
-		return (audioNode && audioNode.toString() === "[object OscillatorNode]");
+		return (audioNode && (audioNode.toString() === "[object OscillatorNode]" || audioNode.toString() === "[object WebKitOscillatorNode]"));
 	},
 
 	isAudioBufferSourceNode: function(audioNode) {

--- a/tests/Sound.test.js
+++ b/tests/Sound.test.js
@@ -5,7 +5,7 @@ describe('Sound', function() {
 		it('should create by default a sinewave sound with 440 frequency', function() {
 			var sound = new Pizzicato.Sound();
 
-			expect(toString.call(sound.getSourceNode())).toBe('[object OscillatorNode]');
+			expect(['[object OscillatorNode]', '[object WebKitOscillatorNode]']).toContain(toString.call(sound.getSourceNode()));
 			expect(sound.getSourceNode().frequency.value).toBe(440);
 			expect(sound.getSourceNode().type).toBe('sine');
 		});
@@ -79,7 +79,7 @@ describe('Sound', function() {
 
 			it('should create an oscillator node', function() {
 				var sound = new Pizzicato.Sound({ source: 'wave' });
-				expect(toString.call(sound.getSourceNode())).toBe('[object OscillatorNode]');
+				expect(['[object OscillatorNode]', '[object WebKitOscillatorNode]']).toContain(toString.call(sound.getSourceNode()));
 			});
 
 			it('should execute callback function', function(done) {


### PR DESCRIPTION
This adds a secondary identifier for checking that an object is an OscillatorNode, to be compatible with how WebKit (Safari) changed their object identifiers. 

I ran the tests and they were all still green on Firefox. I additionally ran the tests on Safari (but did not change the `karma.config.js` file to include Safari because I assume that many others will not have Safari available for test). The suite on Safari failed 11 tests, but I was able to correct two of them which were directly linked to this issue. I didn't look into the other failures. Everything should still be green on FF however.