### PR TITLE
Allow passing constraints for Sounds of type "input"

### DIFF
--- a/src/Sound.js
+++ b/src/Sound.js
@@ -169,10 +169,11 @@ Pizzicato.Sound = function(description, callback) {
 				callback(error);
 		};
 
+		const audioConstraints = options && options.audioConstraints ? options.audioConstraints : true;
 		if (!!navigator.mediaDevices.getUserMedia)
-			navigator.mediaDevices.getUserMedia({ audio: true }).then(handleStream).catch(handleError);
+			navigator.mediaDevices.getUserMedia({audio: audioConstraints}).then(handleStream).catch(handleError);
 		else
-			navigator.getUserMedia({ audio: true }, handleStream, handleError);
+			navigator.getUserMedia({audio: audioConstraints}, handleStream, handleError);
 	}
 
 


### PR DESCRIPTION
Currently, it is not possible to pass specific constraints to the `getUserMedia` function. Allow setting a property which influences the passed parameter to the `getUserMedia` function.